### PR TITLE
feat: pass the destination port via env var LLMUX_DEST_PORT=nnnnn

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,12 @@ models:
       curl -sf http://localhost:8001/health
 ```
 
-Hooks are executed via `sh -c` with `LLMUX_MODEL` set in the environment.
+Hooks are executed via `sh -c` with an environment that includes:
+  - the environment from the llmux process
+  - configuration parameters of the model being awoken/evicted:
+    - `LLMUX_MODEL` the name of the model (i.e. the key under `models`)
+    - `LLMUX_DEST_PORT` the assigned port number for the model
+
 They can be inline scripts (YAML `|` syntax) or paths to executables.
 
 ### Policy

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -12,6 +12,12 @@ use std::collections::HashMap;
 use tokio::process::Command;
 use tracing::{debug, info, warn};
 
+/// The name of the model.
+const LLMUX_ENV_MODEL: &str = "LLMUX_MODEL";
+
+/// The destination port for the model entry.
+const LLMUX_ENV_DEST_PORT: &str = "LLMUX_DEST_PORT";
+
 /// Errors from hook script execution
 #[derive(Debug, thiserror::Error)]
 pub enum HookError {
@@ -61,7 +67,7 @@ impl HookRunner {
             .configs
             .get(model)
             .ok_or_else(|| HookError::ModelNotFound(model.to_string()))?;
-        run_hook(&config.wake, model, "wake").await
+        run_hook(&config.wake, model, config.port, "wake").await
     }
 
     /// Run the sleep script for a model. Returns Ok(()) when the model is asleep.
@@ -70,7 +76,7 @@ impl HookRunner {
             .configs
             .get(model)
             .ok_or_else(|| HookError::ModelNotFound(model.to_string()))?;
-        run_hook(&config.sleep, model, "sleep").await
+        run_hook(&config.sleep, model, config.port, "sleep").await
     }
 
     /// Run the alive script for a model. Returns true if healthy, false if not.
@@ -82,7 +88,7 @@ impl HookRunner {
             .configs
             .get(model)
             .ok_or_else(|| HookError::ModelNotFound(model.to_string()))?;
-        match run_hook(&config.alive, model, "alive").await {
+        match run_hook(&config.alive, model, config.port, "alive").await {
             Ok(()) => Ok(true),
             Err(HookError::Failed { .. }) => Ok(false),
             Err(e) => Err(e),
@@ -90,15 +96,17 @@ impl HookRunner {
     }
 }
 
-async fn run_hook(script: &str, model: &str, hook_name: &str) -> Result<(), HookError> {
+async fn run_hook(script: &str, model: &str, port: u16, hook_name: &str) -> Result<(), HookError> {
     debug!(model = %model, hook = %hook_name, "Running hook");
 
     let start = std::time::Instant::now();
 
+    let port_s = port.to_string();
     let output = Command::new("sh")
         .arg("-c")
         .arg(script)
-        .env("LLMUX_MODEL", model)
+        .env(LLMUX_ENV_MODEL, model)
+        .env(LLMUX_ENV_DEST_PORT, &port_s)
         .output()
         .await
         .map_err(HookError::Io)?;
@@ -160,4 +168,118 @@ async fn run_hook(script: &str, model: &str, hook_name: &str) -> Result<(), Hook
         "Hook completed"
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn hook_scripts_receive_environment() {
+        // 1. the hook script here uses only builtin commands from sh (no additional dependencies introduced).
+        // 2. validation relies on returning the environment through stderr
+        let res = run_hook("printenv >&2; exit 300", "dummy-1B", 1999u16, "testhook")
+            .await
+            .expect_err("should fail");
+
+        let env_str = match res {
+            HookError::Failed {
+                model,
+                hook,
+                code,
+                stderr,
+            } => {
+                assert_eq!(model, "dummy-1B");
+                assert_eq!(hook, "testhook");
+                assert_eq!(code, 300 % 256);
+                stderr
+            }
+            x => {
+                panic!("expected HookError::Failed but got {x:?}");
+            }
+        };
+
+        let lines: Vec<String> = env_str.split("\n").map(String::from).collect();
+
+        // the child environment receives this cargo environment variable if and only if
+        // it's passed down from the parent.
+        lines
+            .iter()
+            .find(|v| v.starts_with("CARGO_PKG_VERSION="))
+            .expect("parent environment should be passed down.");
+
+        // using hardcoded constants for stability.
+        lines
+            .iter()
+            .find(|v| *v == "LLMUX_MODEL=dummy-1B")
+            .expect("llmux must set LLMUX_MODEL to the model name");
+
+        lines
+            .iter()
+            .find(|v| *v == "LLMUX_DEST_PORT=1999")
+            .expect("llmux must set LLMUX_DEST_PORT to the port onto which the model is served");
+    }
+
+    #[tokio::test]
+    async fn hook_script_tolerates_garbage_output() {
+        // \200 is octal sequence for 0x80, which should be part of a 2-byte codepoint
+        run_hook("echo 'not utf\\200-8$'; exit 0", "model", 10u16, "testhook")
+            .await
+            .expect("non-utf8 output should be parsed gracefully");
+
+        run_hook(
+            "echo 'not utf\\200-8$' >&2; exit 0",
+            "model",
+            10u16,
+            "testhook",
+        )
+        .await
+        .expect("non-utf8 output should be parsed gracefully");
+
+        // the stderr returned on a failure is lossy when error is not utf-8
+        let out = run_hook(
+            "echo 'not utf\\200-8' >&2; exit 3",
+            "model",
+            10u16,
+            "testhook",
+        )
+        .await
+        .expect_err("exit 1 should trigger error");
+
+        match out {
+            HookError::Failed {
+                model: _,
+                hook: _,
+                code,
+                stderr,
+            } => {
+                assert_eq!(code, 3);
+                // bad codes replaced with U+FFFD
+                assert_eq!("not utf\u{fffd}-8\n", stderr);
+            }
+            err => panic!("unexpected error: {err:?}"),
+        };
+    }
+
+    #[tokio::test]
+    async fn hook_script_omits_stdout_on_error() {
+        // \200 is octal sequence for 0x80, which should introduce a 2-byte codepoint.
+        let out = run_hook("echo out; echo err >&2; exit 1", "model", 10u16, "testhook")
+            .await
+            .expect_err("exit 1 should trigger a failure");
+
+        match out {
+            HookError::Failed {
+                model: _,
+                hook: _,
+                code,
+                stderr,
+            } => {
+                assert_eq!(code, 1);
+                // stdout is not part of the mix
+                assert_eq!("err\n", stderr);
+            }
+            err => panic!("unexpected error: {err:?}"),
+        };
+    }
 }


### PR DESCRIPTION
Thank you for putting this repo out there!

After playing around with configuring models, I discovered that I repeatedly had to pass the port around everywhere in every command, so I found it would be convenient to have it as part of the shell environment.

I also added some unit tests to validate the contract. 

Things to consider:
- different variable name

- allow configuring the destination hostname and port as part of a `host:port` destination string.  The current `port: N` config key is effectively a shorthand notation for `localhost:N` if we generalize.


