### PR TITLE
Adding the ability to configure destination host and port for models.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,6 +639,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "llmux"
 version = "2.4.0"
 dependencies = [
@@ -652,6 +664,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tower",
@@ -928,6 +941,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,6 +1204,19 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
+tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ models:
 
   mistral:
     port: 8002
+    host: 192.168.10.2
     wake: ./scripts/wake-mistral.sh
     sleep: ./scripts/sleep-mistral.sh
-    alive: curl -sf http://localhost:8002/health
+    alive: curl -sf http://192.168.10.2:8002/health
 
 port: 3000
 ```
@@ -63,15 +64,22 @@ run `sleep-llama.sh`, then `wake-mistral.sh`, and proxy the request through.
 ## How it works
 
 ```
-Client requests
-     |
-+---------+
-|  llmux  |   port 3000 (OpenAI-compatible proxy)
-+---------+
- /         \
-[8001]    [8002]
- llama     mistral
-(active)   (sleeping)
+Client Requests
+    │
+    ▼
+┌──────────────────────────────────────┐
+│           llmux (localhost:3000)     │
+│     OpenAI-compatible proxy/router   │
+└───────────────┬──────────────────────┘
+                │ forwarded
+      ┌─────────┴─────────┐
+      │                   │
+      ▼                   ▼
+┌────────────────┐  ┌────────────────────┐
+│ llama          │  │ mistral            │
+│ localhost:8001 │  │ 192.168.10.2:8002  │
+│ (active)       │  │ (sleeping)         │
+└────────────────┘  └────────────────────┘
 ```
 
 1. **Middleware** extracts the `model` field from the request JSON body
@@ -79,14 +87,14 @@ Client requests
    - Drains in-flight requests for the current model
    - Runs the **sleep** hook on the current model
    - Runs the **wake** hook on the target model
-3. **Proxy** forwards the request to `localhost:<model_port>`
+3. **Proxy** forwards the request to `<model_host>:<model_port>` (model host defaults to the same host as llmux).
 4. In-flight tracking uses RAII guards that hold through streaming responses
 
 ## Configuration
 
 ### Models
 
-Each model needs a `port` and three hooks:
+Each model needs a `port`, an optional `host` (address), and three hooks:
 
 ```yaml
 models:
@@ -109,8 +117,14 @@ models:
       curl -sf http://localhost:8001/health
 ```
 
-Hooks are executed via `sh -c` with `LLMUX_MODEL` set in the environment.
-They can be inline scripts (YAML `|` syntax) or paths to executables.
+Hooks are executed via `sh -c` with an environment that includes:
+  - the environment from the llmux process
+  - configuration parameters of the model being awoken/evicted:
+    - `LLMUX_MODEL` the name of the model (i.e. the key under `models`)
+    - `LLMUX_DEST_HOST` the host address (or hostname) on which the inference server is listening
+    - `LLMUX_DEST_PORT` the tcp port address on which the inference server is listening
+    
+The hooks can be inline scripts (YAML `|` syntax) or paths to executables.
 
 ### Policy
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,9 +5,11 @@
 //!
 //! Supports both YAML and JSON config files (detected by extension).
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
+use http::Uri;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::net::IpAddr;
 use std::path::Path;
 use std::time::Duration;
 
@@ -46,30 +48,87 @@ pub struct Config {
 /// All hooks are executed via `sh -c` with LLMUX_MODEL set in the environment.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelConfig {
-    /// Port where the model's inference server listens
+    /// Port on which the model's inference server listens.
     pub port: u16,
+
+    /// Hostname/address on which the model's inference server listens.
+    #[serde(default = "default_host")]
+    pub host: String,
 
     /// Script to bring the model to a running state (idempotent).
     /// Can be a path to an executable or an inline shell script.
-    /// Called with LLMUX_MODEL env var set to the model name.
+    /// Called with LLMUX_* env vars set to the model configuration.
     /// Must exit 0 when the model is ready to serve requests.
     pub wake: String,
 
     /// Script to put the model to sleep / free resources.
     /// Can be a path to an executable or an inline shell script.
-    /// Called with LLMUX_MODEL env var set to the model name.
+    /// Called with LLMUX_* env vars set to the model configuration.
     /// Must exit 0 when the model is fully stopped/sleeping.
     pub sleep: String,
 
     /// Script to check if the model is alive and healthy.
     /// Can be a path to an executable or an inline shell script.
-    /// Called with LLMUX_MODEL env var set to the model name.
+    /// Called with LLMUX_* env vars set to the model configuration.
     /// Exit 0 = healthy, non-zero = unhealthy.
     pub alive: String,
 }
 
+impl ModelConfig {
+    fn is_valid_hostname(host: &str) -> bool {
+        if host.parse::<IpAddr>().is_ok() {
+            return true;
+        }
+
+        // "link-local IPv6 zone IDs are not supported". -- e.g. "fe80::1%eth0"
+        if host.contains('%') {
+            return false;
+        }
+
+        if host.is_empty() || host.len() > 253 {
+            return false;
+        }
+        host.split('.').all(|label| {
+            !label.is_empty()
+                && label.len() <= 63
+                && label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+                && !label.starts_with('-')
+                && !label.ends_with('-')
+        })
+    }
+
+    /// validates syntax and bounds, but does not perform network lookups
+    pub fn validate(&self) -> Result<()> {
+        anyhow::ensure!(
+            ModelConfig::is_valid_hostname(&self.host),
+            "invalid hostname: {:?}",
+            self.host
+        );
+
+        // we'll be calling this at runtime when forwarding the connection.
+        // better check now than fail later.
+        let authority = if self.host.contains(":") {
+            // ipv6 addresses require braces [] in URLs.
+            format!("[{}]", self.host)
+        } else {
+            self.host.to_string()
+        };
+        format!("http://{}:{}/", authority, self.port).parse::<Uri>()?;
+
+        if self.port == 0 {
+            Err(anyhow!("port 0 is reserved"))
+        } else {
+            Ok(())
+        }
+    }
+}
+
 fn default_port() -> u16 {
     3000
+}
+
+fn default_host() -> String {
+    "localhost".to_string()
 }
 
 impl Config {
@@ -81,12 +140,24 @@ impl Config {
 
         let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
-        match ext {
+        let raw_config: Config = match ext {
             "yaml" | "yml" => serde_yaml::from_str(&contents)
                 .with_context(|| format!("Failed to parse YAML config: {}", path.display())),
             _ => serde_json::from_str(&contents)
                 .with_context(|| format!("Failed to parse JSON config: {}", path.display())),
+        }?;
+
+        raw_config.validate()?;
+        Ok(raw_config)
+    }
+
+    fn validate(&self) -> Result<()> {
+        for (model_name, model_config) in &self.models {
+            model_config
+                .validate()
+                .with_context(|| format!("model {:?} failed validation", model_name))?;
         }
+        Ok(())
     }
 }
 
@@ -134,6 +205,73 @@ impl PolicyConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_invalid_port() {
+        let mc = ModelConfig {
+            host: "localhost".to_string(),
+            port: 0,
+            wake: "".to_string(),
+            sleep: "".to_string(),
+            alive: "".to_string(),
+        };
+        let err = mc.validate().expect_err("port 0 is bad");
+        assert!(err.to_string().contains("port"));
+    }
+
+    #[test]
+    fn test_bad_hosts_are_rejected() {
+        let cases = [
+            ("10.0.0.2", true),
+            ("example.com", true),
+            ("bad host", false),
+            ("  ", false),
+            ("localhost:5000", false),
+            ("::1", true),
+            ("foo-%2D-blah", false),
+            ("http://localhost", false),
+            (" fat-finger.com", false),
+            ("10..54", false),
+            ("", false),
+        ];
+        for (input, expected) in cases {
+            let mc = ModelConfig {
+                host: input.to_string(),
+                port: 8000,
+                wake: "".to_string(),
+                sleep: "".to_string(),
+                alive: "".to_string(),
+            };
+            assert_eq!(mc.validate().is_ok(), expected, "input: {input:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_parse_from_file_applies_validation() {
+        let json_with_bad_host = r#"{
+            "models": {
+                "llama": {
+                    "port": 8001,
+                    "host": "-bad.host-",
+                    "wake": "./scripts/wake-llama.sh",
+                    "sleep": "./scripts/sleep-llama.sh",
+                    "alive": "./scripts/alive-llama.sh"
+                }
+            },
+            "policy": {
+                "request_timeout_secs": 30
+            },
+            "port": 3000
+        }"#;
+        let mut file = tempfile::NamedTempFile::new().expect("should work");
+        writeln!(file, "{json_with_bad_host}").expect("should be able to write");
+        let path = file.path();
+        let err = Config::from_file(path)
+            .await
+            .expect_err("supposed to crash on a bad host name");
+        assert!(err.to_string().contains("model \"llama\" failed validation"), "{:?}", err);
+    }
 
     #[test]
     fn test_parse_json() {
@@ -141,6 +279,7 @@ mod tests {
             "models": {
                 "llama": {
                     "port": 8001,
+                    "host": "host.docker.internal",
                     "wake": "./scripts/wake-llama.sh",
                     "sleep": "./scripts/sleep-llama.sh",
                     "alive": "./scripts/alive-llama.sh"
@@ -159,8 +298,11 @@ mod tests {
         }"#;
 
         let config: Config = serde_json::from_str(json).unwrap();
+        config.validate().expect("it's valid");
         assert_eq!(config.models.len(), 2);
         assert_eq!(config.models["llama"].port, 8001);
+        assert_eq!(config.models["mistral"].host, "localhost");
+        assert_eq!(config.models["llama"].host, "host.docker.internal");
         assert_eq!(config.policy.request_timeout_secs, Some(30));
     }
 
@@ -183,6 +325,7 @@ port: 4000
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(config.models.len(), 1);
         assert_eq!(config.models["llama"].port, 8001);
+        assert_eq!(config.models["llama"].host, "localhost");
         assert_eq!(config.models["llama"].wake, "./scripts/wake-llama.sh");
         assert!(config.models["llama"].sleep.contains("kill"));
         assert_eq!(config.policy.request_timeout_secs, Some(60));

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -12,6 +12,15 @@ use std::collections::HashMap;
 use tokio::process::Command;
 use tracing::{debug, info, warn};
 
+/// The name of the model.
+const LLMUX_ENV_MODEL: &str = "LLMUX_MODEL";
+
+/// The destination hostname/ip for the inference server
+const LLMUX_ENV_DEST_HOST: &str = "LLMUX_DEST_HOST";
+
+/// The destination port for the inference server
+const LLMUX_ENV_DEST_PORT: &str = "LLMUX_DEST_PORT";
+
 /// Errors from hook script execution
 #[derive(Debug, thiserror::Error)]
 pub enum HookError {
@@ -44,8 +53,8 @@ impl HookRunner {
         self.configs.keys().cloned().collect()
     }
 
-    pub fn model_port(&self, model: &str) -> Option<u16> {
-        self.configs.get(model).map(|c| c.port)
+    pub fn model_dest(&self, model: &str) -> Option<(String, u16)> {
+        self.configs.get(model).map(|c| (c.host.clone(), c.port))
     }
 
     pub fn is_registered(&self, model: &str) -> bool {
@@ -61,7 +70,7 @@ impl HookRunner {
             .configs
             .get(model)
             .ok_or_else(|| HookError::ModelNotFound(model.to_string()))?;
-        run_hook(&config.wake, model, "wake").await
+        run_hook(&config.wake, model, config, "wake").await
     }
 
     /// Run the sleep script for a model. Returns Ok(()) when the model is asleep.
@@ -70,7 +79,7 @@ impl HookRunner {
             .configs
             .get(model)
             .ok_or_else(|| HookError::ModelNotFound(model.to_string()))?;
-        run_hook(&config.sleep, model, "sleep").await
+        run_hook(&config.sleep, model, config, "sleep").await
     }
 
     /// Run the alive script for a model. Returns true if healthy, false if not.
@@ -82,7 +91,7 @@ impl HookRunner {
             .configs
             .get(model)
             .ok_or_else(|| HookError::ModelNotFound(model.to_string()))?;
-        match run_hook(&config.alive, model, "alive").await {
+        match run_hook(&config.alive, model, config, "alive").await {
             Ok(()) => Ok(true),
             Err(HookError::Failed { .. }) => Ok(false),
             Err(e) => Err(e),
@@ -90,15 +99,23 @@ impl HookRunner {
     }
 }
 
-async fn run_hook(script: &str, model: &str, hook_name: &str) -> Result<(), HookError> {
+async fn run_hook(
+    script: &str,
+    model: &str,
+    config: &ModelConfig,
+    hook_name: &str,
+) -> Result<(), HookError> {
     debug!(model = %model, hook = %hook_name, "Running hook");
 
     let start = std::time::Instant::now();
 
+    let port_s = config.port.to_string();
     let output = Command::new("sh")
         .arg("-c")
         .arg(script)
-        .env("LLMUX_MODEL", model)
+        .env(LLMUX_ENV_MODEL, model)
+        .env(LLMUX_ENV_DEST_PORT, &port_s)
+        .env(LLMUX_ENV_DEST_HOST, &config.host)
         .output()
         .await
         .map_err(HookError::Io)?;
@@ -160,4 +177,140 @@ async fn run_hook(script: &str, model: &str, hook_name: &str) -> Result<(), Hook
         "Hook completed"
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn hook_scripts_receive_environment() {
+        let config = ModelConfig {
+            host: "test-host.example.org".to_string(),
+            port: 1999,
+            wake: "printenv >&2; exit 300".to_string(),
+            sleep: "".to_string(),
+            alive: "".to_string(),
+        };
+
+        // 1. the hook script here uses only builtin commands from sh (no additional dependencies introduced).
+        // 2. validation relies on returning the environment through stderr
+        let res = run_hook(&config.wake, "dummy-1B", &config, "wake")
+            .await
+            .expect_err("should fail");
+
+        let env_str = match res {
+            HookError::Failed {
+                model,
+                hook,
+                code,
+                stderr,
+            } => {
+                assert_eq!(model, "dummy-1B");
+                assert_eq!(hook, "wake");
+                assert_eq!(code, 300 % 256);
+                stderr
+            }
+            err => {
+                panic!("expected HookError::Failed but got {err:?}");
+            }
+        };
+
+        let lines: Vec<String> = env_str.split("\n").map(String::from).collect();
+
+        // the child environment receives this cargo environment variable if and only if
+        // it's passed down from the parent.
+        lines
+            .iter()
+            .find(|v| v.starts_with("CARGO_PKG_VERSION="))
+            .expect("parent environment should be passed down.");
+
+        // using hardcoded constants for stability.
+        lines
+            .iter()
+            .find(|v| *v == "LLMUX_MODEL=dummy-1B")
+            .expect("llmux must set LLMUX_MODEL to the model name");
+
+        lines
+            .iter()
+            .find(|v| *v == "LLMUX_DEST_PORT=1999")
+            .expect("llmux must set LLMUX_DEST_PORT to the port onto which the model is served");
+
+        lines
+            .iter()
+            .find(|v| *v == "LLMUX_DEST_HOST=test-host.example.org")
+            .expect("llmux must set LLMUX_DEST_HOST to the hostname/ip where the model is served");
+    }
+
+    #[tokio::test]
+    async fn hook_script_tolerates_garbage_output() {
+        let config = ModelConfig {
+            host: "localhost".to_string(),
+            port: 10,
+            // \200 is octal sequence for 0x80, which should be part of a 2-byte codepoint
+            // command is successful exit 0
+            wake: "echo 'not utf\\200-8'; exit 0".to_string(),
+            // same as wake, but on stderr. command is successful exit 0
+            sleep: "echo 'not utf\\200-8' >&2; exit 0".to_string(),
+            // non-utf-8 data on stderr, command exit 3
+            alive: "echo 'not utf\\200-8' >&2; exit 3".to_string(),
+        };
+
+        run_hook(&config.wake, "model", &config, "wake")
+            .await
+            .expect("non-utf8 stdout should be parsed gracefully on success");
+
+        run_hook(&config.sleep, "model", &config, "sleep")
+            .await
+            .expect("non-utf8 stderr should be parsed gracefully on success");
+
+        // the stderr returned on a failure is lossy when error is not utf-8
+        let out = run_hook(&config.alive, "model", &config, "alive")
+            .await
+            .expect_err("exit 3 should trigger error");
+
+        match out {
+            HookError::Failed {
+                model: _,
+                hook: _,
+                code,
+                stderr,
+            } => {
+                assert_eq!(code, 3);
+                // bad codes replaced with U+FFFD
+                assert_eq!("not utf\u{fffd}-8\n", stderr);
+            }
+            err => panic!("unexpected error: {err:?}"),
+        };
+    }
+
+    // when there is an error in one of the hook scripts. only include stderr in the error message.
+    #[tokio::test]
+    async fn hook_script_omits_stdout_on_error() {
+        let config = ModelConfig {
+            host: "localhost".to_string(),
+            port: 10,
+            // write to stdout and stderr, and fail
+            wake: "echo out; echo err >&2; exit 1".to_string(),
+            sleep: "".to_string(),
+            alive: "".to_string(),
+        };
+        let out = run_hook(&config.wake, "model", &config, "wake")
+            .await
+            .expect_err("exit 1 should trigger a failure");
+
+        match out {
+            HookError::Failed {
+                model: _,
+                hook: _,
+                code,
+                stderr,
+            } => {
+                assert_eq!(code, 1);
+                // stdout is not included in the error message reported to user
+                assert_eq!("err\n", stderr);
+            }
+            err => panic!("unexpected error: {err:?}"),
+        };
+    }
 }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -142,9 +142,9 @@ where
             .record(request_start.elapsed().as_secs_f64());
 
             // Set proxy target so the proxy handler knows where to forward
-            let port = switcher.model_port(&model).unwrap();
+            let (host, port) = switcher.model_dest(&model).unwrap();
             let mut parts = parts;
-            parts.extensions.insert(ProxyTarget { port });
+            parts.extensions.insert(ProxyTarget { host, port });
 
             let req = Request::from_parts(parts, Body::from(body_bytes));
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -9,9 +9,10 @@ use hyper_util::rt::TokioExecutor;
 use tracing::error;
 
 /// Target port for a proxied request, set by the middleware as a request extension.
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct ProxyTarget {
     pub port: u16,
+    pub host: String,
 }
 
 /// Shared state for the proxy handler.
@@ -38,10 +39,10 @@ impl ProxyState {
 /// Reads the [`ProxyTarget`] extension (set by the model switcher middleware)
 /// to determine which localhost port to forward to.
 pub async fn proxy_handler(State(state): State<ProxyState>, req: Request<Body>) -> Response<Body> {
-    let target = req.extensions().get::<ProxyTarget>().copied();
+    let target = req.extensions().get::<ProxyTarget>().cloned();
 
     match target {
-        Some(ProxyTarget { port }) => match forward(state.client, req, port).await {
+        Some(ProxyTarget { host, port }) => match forward(state.client, req, &host, port).await {
             Ok(resp) => resp,
             Err(e) => {
                 error!(error = %e, "Proxy error");
@@ -55,6 +56,7 @@ pub async fn proxy_handler(State(state): State<ProxyState>, req: Request<Body>) 
 async fn forward(
     client: Client<HttpConnector, Body>,
     mut req: Request<Body>,
+    host: &str,
     port: u16,
 ) -> Result<Response<Body>, hyper_util::client::legacy::Error> {
     // Rewrite URI to target backend
@@ -64,7 +66,14 @@ async fn forward(
         .map(|pq| pq.to_string())
         .unwrap_or_else(|| "/".to_string());
 
-    let uri: Uri = format!("http://127.0.0.1:{}{}", port, path_and_query)
+    let host_part = if host.contains(':') {
+        // ipv6 addresses like ::1 need to be wrapped in [] when added to a URL
+        format!("[{host}]")
+    } else {
+        host.to_string()
+    };
+
+    let uri: Uri = format!("http://{host_part}:{port}{path_and_query}")
         .parse()
         .expect("valid proxy URI");
 

--- a/src/switcher.rs
+++ b/src/switcher.rs
@@ -134,8 +134,8 @@ impl ModelSwitcher {
         self.inner.model_states.contains_key(model)
     }
 
-    pub fn model_port(&self, model: &str) -> Option<u16> {
-        self.inner.hooks.model_port(model)
+    pub fn model_dest(&self, model: &str) -> Option<(String, u16)> {
+        self.inner.hooks.model_dest(model)
     }
 
     pub fn in_flight_count(&self, model: &str) -> usize {
@@ -805,6 +805,7 @@ mod tests {
             "model-a".to_string(),
             ModelConfig {
                 port: 8001,
+                host: "localhost".to_string(),
                 wake: "true".to_string(),
                 sleep: "true".to_string(),
                 alive: "true".to_string(),
@@ -814,6 +815,7 @@ mod tests {
             "model-b".to_string(),
             ModelConfig {
                 port: 8002,
+                host: "host8002".to_string(),
                 wake: "true".to_string(),
                 sleep: "true".to_string(),
                 alive: "true".to_string(),
@@ -877,14 +879,37 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_model_port() {
+    async fn test_model_dest() {
         let hooks = make_test_hooks();
         let policy = Box::new(FifoPolicy::default());
         let switcher = ModelSwitcher::new(hooks, policy);
 
-        assert_eq!(switcher.model_port("model-a"), Some(8001));
-        assert_eq!(switcher.model_port("model-b"), Some(8002));
-        assert_eq!(switcher.model_port("model-c"), None);
+        assert_eq!(
+            switcher.model_dest("model-a"),
+            Some(("localhost".to_string(), 8001))
+        );
+        assert_eq!(
+            switcher.model_dest("model-b"),
+            Some(("host8002".to_string(), 8002))
+        );
+        assert_eq!(switcher.model_dest("model-c"), None);
+    }
+
+    #[tokio::test]
+    async fn test_model_jpmp() {
+        let hooks = make_test_hooks();
+        let policy = Box::new(FifoPolicy::default());
+        let switcher = ModelSwitcher::new(hooks, policy);
+
+        assert_eq!(
+            switcher.model_dest("model-a"),
+            Some(("localhost".to_string(), 8001))
+        );
+        assert_eq!(
+            switcher.model_dest("model-b"),
+            Some(("host8002".to_string(), 8002))
+        );
+        assert_eq!(switcher.model_dest("model-c"), None);
     }
 
     #[tokio::test]

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -13,6 +13,7 @@ use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 use tokio::net::TcpListener;
@@ -37,8 +38,28 @@ impl MockHooks {
     }
 }
 
+// produces a sequence of loopback addresses
+// 127.0.0.1 -> ... 127.0.0.255
+// 127.0.1.0 -> ... 127.0.1.255
+// ...
+// 127.255....
+fn next_loopback_address() -> String {
+    static COUNTER: OnceLock<AtomicUsize> = OnceLock::new();
+    let counter = COUNTER.get_or_init(|| AtomicUsize::new(1));
+    // Increment the counter
+    let val = counter.fetch_add(1, Ordering::Relaxed);
+    let d = val % 256;
+    let c = (val >> 8) % 256;
+    let b = (val >> 16) % 256;
+
+    if b == 255 && c == 255 && d == 255 {
+        panic!("exhausted 127/8 loopback. such coverage.");
+    }
+    format!("127.{b}.{c}.{d}")
+}
+
 /// Spawn a mock backend that echoes the model name and a counter.
-async fn spawn_mock_backend(port: u16) -> (SocketAddr, Arc<AtomicUsize>) {
+async fn spawn_mock_backend() -> (SocketAddr, Arc<AtomicUsize>) {
     let counter = Arc::new(AtomicUsize::new(0));
     let counter_clone = counter.clone();
 
@@ -61,9 +82,10 @@ async fn spawn_mock_backend(port: u16) -> (SocketAddr, Arc<AtomicUsize>) {
         }),
     );
 
-    let listener = TcpListener::bind(format!("127.0.0.1:{}", port))
-        .await
-        .unwrap();
+    // bind to the next address in loopback, random port.
+    let bind_host = next_loopback_address();
+    println!("{bind_host}");
+    let listener = TcpListener::bind(format!("{bind_host}:0")).await.unwrap();
     let addr = listener.local_addr().unwrap();
 
     tokio::spawn(async move {
@@ -78,8 +100,8 @@ async fn spawn_mock_backend(port: u16) -> (SocketAddr, Arc<AtomicUsize>) {
 
 /// Build a test config with two models.
 fn test_config(
-    model_a_port: u16,
-    model_b_port: u16,
+    model_a_dest: &SocketAddr,
+    model_b_dest: &SocketAddr,
     hooks_a: &MockHooks,
     hooks_b: &MockHooks,
 ) -> Config {
@@ -87,7 +109,8 @@ fn test_config(
     models.insert(
         "model-a".to_string(),
         ModelConfig {
-            port: model_a_port,
+            host: model_a_dest.ip().to_string(),
+            port: model_a_dest.port(),
             wake: hooks_a.wake.clone(),
             sleep: hooks_a.sleep.clone(),
             alive: hooks_a.alive.clone(),
@@ -96,7 +119,8 @@ fn test_config(
     models.insert(
         "model-b".to_string(),
         ModelConfig {
-            port: model_b_port,
+            host: model_b_dest.ip().to_string(),
+            port: model_b_dest.port(),
             wake: hooks_b.wake.clone(),
             sleep: hooks_b.sleep.clone(),
             alive: hooks_b.alive.clone(),
@@ -145,10 +169,10 @@ async fn test_single_model_request() {
     let hooks_a = MockHooks::new(0, 0); // instant wake/sleep
     let hooks_b = MockHooks::new(0, 0);
 
-    let (addr_a, counter_a) = spawn_mock_backend(0).await;
-    let (addr_b, _counter_b) = spawn_mock_backend(0).await;
+    let (addr_a, counter_a) = spawn_mock_backend().await;
+    let (addr_b, _counter_b) = spawn_mock_backend().await;
 
-    let config = test_config(addr_a.port(), addr_b.port(), &hooks_a, &hooks_b);
+    let config = test_config(&addr_a, &addr_b, &hooks_a, &hooks_b);
     let (app, _switcher) = llmux::build_app(config).await.unwrap();
 
     let (status, body) = chat_request(&app, "model-a").await;
@@ -163,10 +187,10 @@ async fn test_model_switch() {
     let hooks_a = MockHooks::new(10, 10); // 10ms wake/sleep
     let hooks_b = MockHooks::new(10, 10);
 
-    let (addr_a, counter_a) = spawn_mock_backend(0).await;
-    let (addr_b, counter_b) = spawn_mock_backend(0).await;
+    let (addr_a, counter_a) = spawn_mock_backend().await;
+    let (addr_b, counter_b) = spawn_mock_backend().await;
 
-    let config = test_config(addr_a.port(), addr_b.port(), &hooks_a, &hooks_b);
+    let config = test_config(&addr_a, &addr_b, &hooks_a, &hooks_b);
     let (app, _switcher) = llmux::build_app(config).await.unwrap();
 
     // First request: model-a (cold start)
@@ -189,10 +213,10 @@ async fn test_same_model_no_switch() {
     let hooks_a = MockHooks::new(10, 10);
     let hooks_b = MockHooks::new(10, 10);
 
-    let (addr_a, counter_a) = spawn_mock_backend(0).await;
-    let (addr_b, counter_b) = spawn_mock_backend(0).await;
+    let (addr_a, counter_a) = spawn_mock_backend().await;
+    let (addr_b, counter_b) = spawn_mock_backend().await;
 
-    let config = test_config(addr_a.port(), addr_b.port(), &hooks_a, &hooks_b);
+    let config = test_config(&addr_a, &addr_b, &hooks_a, &hooks_b);
     let (app, _switcher) = llmux::build_app(config).await.unwrap();
 
     for _ in 0..5 {
@@ -211,10 +235,10 @@ async fn test_unknown_model() {
     let hooks_a = MockHooks::new(0, 0);
     let hooks_b = MockHooks::new(0, 0);
 
-    let (addr_a, _) = spawn_mock_backend(0).await;
-    let (addr_b, _) = spawn_mock_backend(0).await;
+    let (addr_a, _) = spawn_mock_backend().await;
+    let (addr_b, _) = spawn_mock_backend().await;
 
-    let config = test_config(addr_a.port(), addr_b.port(), &hooks_a, &hooks_b);
+    let config = test_config(&addr_a, &addr_b, &hooks_a, &hooks_b);
     let (app, _) = llmux::build_app(config).await.unwrap();
 
     let (status, body) = chat_request(&app, "nonexistent").await;
@@ -233,10 +257,10 @@ async fn test_switch_timing() {
     let hooks_a = MockHooks::new(100, 50); // 100ms wake, 50ms sleep
     let hooks_b = MockHooks::new(100, 50);
 
-    let (addr_a, _) = spawn_mock_backend(0).await;
-    let (addr_b, _) = spawn_mock_backend(0).await;
+    let (addr_a, _) = spawn_mock_backend().await;
+    let (addr_b, _) = spawn_mock_backend().await;
 
-    let config = test_config(addr_a.port(), addr_b.port(), &hooks_a, &hooks_b);
+    let config = test_config(&addr_a, &addr_b, &hooks_a, &hooks_b);
     let (app, _switcher) = llmux::build_app(config).await.unwrap();
 
     // First request: cold start wake for model-a (~100ms)
@@ -268,10 +292,10 @@ async fn test_concurrent_same_model() {
     let hooks_a = MockHooks::new(50, 10);
     let hooks_b = MockHooks::new(50, 10);
 
-    let (addr_a, counter_a) = spawn_mock_backend(0).await;
-    let (addr_b, _) = spawn_mock_backend(0).await;
+    let (addr_a, counter_a) = spawn_mock_backend().await;
+    let (addr_b, _) = spawn_mock_backend().await;
 
-    let config = test_config(addr_a.port(), addr_b.port(), &hooks_a, &hooks_b);
+    let config = test_config(&addr_a, &addr_b, &hooks_a, &hooks_b);
     let (app, _) = llmux::build_app(config).await.unwrap();
 
     // Send 10 concurrent requests for model-a
@@ -298,10 +322,10 @@ async fn test_concurrent_different_models() {
     let hooks_a = MockHooks::new(50, 10);
     let hooks_b = MockHooks::new(50, 10);
 
-    let (addr_a, counter_a) = spawn_mock_backend(0).await;
-    let (addr_b, counter_b) = spawn_mock_backend(0).await;
+    let (addr_a, counter_a) = spawn_mock_backend().await;
+    let (addr_b, counter_b) = spawn_mock_backend().await;
 
-    let config = test_config(addr_a.port(), addr_b.port(), &hooks_a, &hooks_b);
+    let config = test_config(&addr_a, &addr_b, &hooks_a, &hooks_b);
     let (app, _) = llmux::build_app(config).await.unwrap();
 
     // Send requests for both models concurrently
@@ -335,10 +359,10 @@ async fn test_list_models() {
     let hooks_a = MockHooks::new(0, 0);
     let hooks_b = MockHooks::new(0, 0);
 
-    let (addr_a, _) = spawn_mock_backend(0).await;
-    let (addr_b, _) = spawn_mock_backend(0).await;
+    let (addr_a, _) = spawn_mock_backend().await;
+    let (addr_b, _) = spawn_mock_backend().await;
 
-    let config = test_config(addr_a.port(), addr_b.port(), &hooks_a, &hooks_b);
+    let config = test_config(&addr_a, &addr_b, &hooks_a, &hooks_b);
     let (app, _) = llmux::build_app(config).await.unwrap();
 
     let req = Request::builder()
@@ -374,10 +398,10 @@ async fn test_switch_cost_tracking() {
     let hooks_a = MockHooks::new(50, 20); // 50ms wake, 20ms sleep
     let hooks_b = MockHooks::new(80, 20); // 80ms wake, 20ms sleep
 
-    let (addr_a, _) = spawn_mock_backend(0).await;
-    let (addr_b, _) = spawn_mock_backend(0).await;
+    let (addr_a, _) = spawn_mock_backend().await;
+    let (addr_b, _) = spawn_mock_backend().await;
 
-    let config = test_config(addr_a.port(), addr_b.port(), &hooks_a, &hooks_b);
+    let config = test_config(&addr_a, &addr_b, &hooks_a, &hooks_b);
     let (app, switcher) = llmux::build_app(config).await.unwrap();
 
     // No costs recorded yet


### PR DESCRIPTION
I  quite like the promise of your repository, thanks for making this public.

So maybe I've got a weird/unique setup, but I'm running llmux from _inside_ a docker container, and my inference servers have bound their listening sockets on the docker bridge, not in localhost inside the llmux host. I effectively need to have llmux forward the request onto `host.docker.internal` (the IP of the gateway on the docker bridge), not localhost.

This change:
--------------

 - adds a `host` key to the model configuration. It's the hostname or the ip address of the inference server for a model. The proxy forwards the request to `<dest_host>:<dest_port>` instead of always `localhost:<port>`.
 - I've defined two more environment variables that are passed to hook scripts:
    - LLMUX_DEST_HOST, and LLMUX_DEST_PORT
 - Added coverage for exit codes, environment variables, and host name validation

Concerns:
------------
- The coverage for domain name resolution issues is not ideal. I think if users pass IPs they won't have problems, but if they pass host names that need resolving, there might be issues in error handling that haven't surfaced before

